### PR TITLE
Restart unless stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ docker run -d \
   --volume ~/roon/music:/music:ro \
   --network host \
   --privileged \
+  --restart unless-stopped \
   elgeeko/roon-server
 ```
 
@@ -70,6 +71,7 @@ docker run -d \
   --volume ~/roon/music:/music:ro \
   --network roon \
   --ip 192.168.1.2 \
+  --restart unless-stopped \
   elgeeko/roon-server
 ```
 


### PR DESCRIPTION
Makes the Docker container restart if it crashes unless you stop it manually. Generally better for people (like me) who have a container break and don't realize it. I forgot to add this when I made the last pull request